### PR TITLE
Eliminate $ENV{MT_HOME} for better readability

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -8,7 +8,7 @@
 
 use strict;
 use warnings;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib"    : 'lib';
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/extlib" : 'extlib';
+use lib 'lib';
+use lib 'extlib';
 use MT::PSGI;
 my $app = MT::PSGI->new()->to_app();

--- a/mt-add-notify.cgi
+++ b/mt-add-notify.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::NotifyList';

--- a/mt-atom.cgi
+++ b/mt-atom.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::AtomServer';

--- a/mt-comments.cgi
+++ b/mt-comments.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::Comments';

--- a/mt-feed.cgi
+++ b/mt-feed.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::ActivityFeeds';

--- a/mt-ftsearch.cgi
+++ b/mt-ftsearch.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::Search::FreeText';

--- a/mt-search.cgi
+++ b/mt-search.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::Search';

--- a/mt-tb.cgi
+++ b/mt-tb.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::Trackback';

--- a/mt-upgrade.cgi
+++ b/mt-upgrade.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::Upgrader';

--- a/mt-view.cgi
+++ b/mt-view.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::Viewer';

--- a/mt-wizard.cgi
+++ b/mt-wizard.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::Wizard';

--- a/mt.cgi
+++ b/mt.cgi
@@ -7,5 +7,5 @@
 # $Id$
 
 use strict;
-use lib $ENV{MT_HOME} ? "$ENV{MT_HOME}/lib" : 'lib';
+use lib 'lib';
 use MT::Bootstrap App => 'MT::App::CMS';


### PR DESCRIPTION
we do not use MT_HOME.
